### PR TITLE
Make lib tslint compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "format": "prettier --write './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
-    "prebuild": "yarn format",
+    "prebuild": "yarn format && yarn lint",
     "build": "tsc",
     "test": "mocha \"build/**/*.spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prettier": "^1.14.3",
     "tslint": "^5.11.0",
     "tslint-immutable": "^4.9.1",
+    "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.1.3"
   }
 }

--- a/src/HttpApi.ts
+++ b/src/HttpApi.ts
@@ -125,7 +125,7 @@ export interface ForgerDetail {
 
 export interface ForgerResponse {
   readonly meta: ForgerMeta;
-  readonly data: ForgerDetail[];
+  readonly data: ReadonlyArray<ForgerDetail>;
 }
 
 export interface Account {
@@ -153,5 +153,5 @@ export interface ResponseObject<T> {
 
 export interface ResponseList<T> {
   readonly meta: any;
-  readonly data: T[];
+  readonly data: ReadonlyArray<T>;
 }

--- a/src/WsApi.spec.ts
+++ b/src/WsApi.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
-import { WsApi } from "./WsApi";
 import { makeNonce } from "./util/nonce";
+import { WsApi } from "./WsApi";
 
 const nodeHostname = process.env.LISK_NODE_HOSTNAME || "testnet.lisk.io";
 const nodeHttpPort = Number.parseInt(process.env.LISK_NODE_PORT || "7000", 10);

--- a/src/WsApi.ts
+++ b/src/WsApi.ts
@@ -6,7 +6,7 @@ import { WampClient } from "./websockets/WampClient";
  * A client for the Lisk p2p Websocket protocol.
  */
 export class WsApi {
-  public options = {
+  public readonly options = {
     hostname: "betanet.lisk.io",
     port: 5001,
     httpPort: 5000,
@@ -22,6 +22,7 @@ export class WsApi {
     },
   };
 
+  // tslint:disable-next-line:readonly-keyword
   private socket: any;
 
   constructor(ip: string, wsPort: number, httpPort: number, query: object) {
@@ -119,12 +120,12 @@ export interface WsBlock {
 }
 
 export interface WsBlockResponse {
-  readonly blocks: WsBlock[];
+  readonly blocks: ReadonlyArray<WsBlock>;
 }
 
 export interface WsPeerResponse {
   readonly success: boolean;
-  readonly peers: PeerInfo[];
+  readonly peers: ReadonlyArray<PeerInfo>;
 }
 
 export interface PeerInfo {

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,8 @@
     "defaultSeverity": "error",
     "extends": [
       "tslint:latest",
-      "tslint-immutable"
+      "tslint-immutable",
+      "tslint-no-unused-expression-chai"
     ],
     "jsRules": {},
     "rules": {

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,7 @@
       "no-loop-statement": false,
       "no-method-signature": true,
       "no-mixed-interface": false,
-      "no-object-mutation": true,
+      "no-object-mutation": false,
       "no-parameter-reassignment": true,
       "no-unnecessary-class": ["allow-static-only"],
       "no-var-keyword": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,13 @@ tslint-immutable@^4.9.1:
   resolved "https://registry.yarnpkg.com/tslint-immutable/-/tslint-immutable-4.9.1.tgz#ca4555d04c3995c92c912b9e57502d423151002c"
   integrity sha512-iIFCq08H4YyNIX0bV5N6fGQtAmjc4OQZKQCgBP5WHgQaITyGAHPVmAw+Yf7qe0zbRCvCDZdrdEC/191fLGFiww==
 
+tslint-no-unused-expression-chai@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.1.4.tgz#f4a2c9dd3306088f44eb7574cf470082b09ade49"
+  integrity sha512-frEWKNTcq7VsaWKgUxMDOB2N/cmQadVkUtUGIut+2K4nv/uFXPfgJyPjuNC/cHyfUVqIkHMAvHOCL+d/McU3nQ==
+  dependencies:
+    tsutils "^3.0.0"
+
 tslint@^5.11.0:
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
@@ -819,6 +826,13 @@ tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.3.1.tgz#b7f34e23efbff41f729a712f0bfc628550c7119c"
+  integrity sha512-reuFQ3/EoMy70YvBPrxe9p7LvA4dCQnvMn+LV8Tv2NKkLCKRHgfB4qFTA9NtWlyYSldTu1dukuquQ3o0mLvsPw==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
This includes a bunch of incompatible changes

- ForgerResponse.data now ReadonlyArray
- ResponseList.data now ReadonlyArray
- Peer.peers now readonly and mutable
- Peer.status now overriden instead of merged
- WsApi.options now readonly
- WsBlockResponse.blocks now ReadonlyArray
- WsPeerResponse.peers now readonly